### PR TITLE
"->' in DataStructure/Hash_cpp.pm for win32

### DIFF
--- a/lib/RPerl/Config.pm
+++ b/lib/RPerl/Config.pm
@@ -394,10 +394,10 @@ for my $i ( 0 .. ( ( scalar @directories_rperl_pm_split ) - 1 ) ) {
 #print {*STDERR} 'in RPerl::Config, have @directories_rperl_split = ', "\n", Dumper(\@directories_rperl_split), "\n";
 
 # NEED FIX: how do we catpath() with some $volume instead of catdir() below, without breaking relative paths?
-$BASE_PATH = File::Spec->catdir(@directories_base_split);
+$BASE_PATH = File::Spec->catpath($volume_loaded, File::Spec->catdir(@directories_base_split));
 if ( $BASE_PATH eq q{} ) {
-    $INCLUDE_PATH = File::Spec->catdir(@directories_rperl_pm_split);
-    $SCRIPT_PATH  = File::Spec->catdir(@directories_rperl_split);
+    $INCLUDE_PATH = File::Spec->catpath($volume_loaded, File::Spec->catdir(@directories_rperl_pm_split));
+    $SCRIPT_PATH  = File::Spec->catpath($volume_loaded, File::Spec->catdir(@directories_rperl_split));
 #    print {*STDERR} 'in RPerl::Config, have $BASE_PATH eq q{} = ', $BASE_PATH, "\n";
 }
 else {

--- a/lib/RPerl/DataStructure/Hash_cpp.pm
+++ b/lib/RPerl/DataStructure/Hash_cpp.pm
@@ -33,7 +33,7 @@ our void_method $cpp_load = sub {
 package main;
 use RPerl::Inline;
 BEGIN { RPerl::diag("[[[ BEGIN 'use Inline' STAGE for 'RPerl/DataStructure/Hash.cpp' ]]]\n" x 0); }
-use Inline (CPP => "$RPerl::INCLUDE_PATH/RPerl/DataStructure/Hash.cpp", \@RPerl::Inline::ARGS);
+use Inline (CPP => '$RPerl::INCLUDE_PATH/RPerl/DataStructure/Hash.cpp', \@RPerl::Inline::ARGS);
 RPerl::diag("[[[ END 'use Inline' STAGE for 'RPerl/DataStructure/Hash.cpp' ]]]\n" x 0);
 1;
 EOF

--- a/t/08_interpret_execute.t
+++ b/t/08_interpret_execute.t
@@ -87,10 +87,15 @@ for my $test_file ( sort keys %{$test_files} ) {
         $pid = open3( 0, \*STDOUT_TEST, \*STDERR_TEST, ( $EXECUTABLE_NAME . ' -I' . $RPerl::INCLUDE_PATH . ' ' . $test_file ) );         # disable STDIN w/ 0
     }
 
-    my $stdout_select = IO::Select->new();
-    my $stderr_select = IO::Select->new();
-    $stdout_select->add( \*STDOUT_TEST );
-    $stderr_select->add( \*STDERR_TEST );
+    my $stdout_select;
+    my $stderr_select;
+    if($^O ne 'MSWin32') {
+        $stdout_select = IO::Select->new();
+        $stderr_select = IO::Select->new();
+        $stdout_select->add( \*STDOUT_TEST );
+        $stderr_select->add( \*STDERR_TEST );
+    }
+
     my $stdout_generated = q{};
     my $stderr_generated = q{};
 
@@ -106,10 +111,10 @@ for my $test_file ( sort keys %{$test_files} ) {
     #        if ( $stderr_select->can_read(0) )  { RPerl::diag('in 08_interpret_execute.t, can read STDERR_TEST for $test_file = ' . $test_file . "\n"); }
 
     waitpid $pid, 0;
-    if ( $stdout_select->can_read(0) ) {
+    if ( $^O eq 'MSWin32' || $stdout_select->can_read(0) ) {
         sysread STDOUT_TEST, $stdout_generated, 4096;
     }
-    if ( $stderr_select->can_read(0) ) {
+    if ( $^O eq 'MSWin32' || $stderr_select->can_read(0) ) {
         sysread STDERR_TEST, $stderr_generated, 4096;
     }
 


### PR DESCRIPTION
"\s" and "\n" in mixed path separator win32 paths can't turn into special
chars, the \ is the dir separator, not an escape char