### PR TITLE
ARM support

### DIFF
--- a/lib/RPerl/Inline.pm
+++ b/lib/RPerl/Inline.pm
@@ -29,7 +29,7 @@ our $CCFLAGSEX = '-Wno-unused-variable -DNO_XSLOCKS -Wno-deprecated -std=c++11 -
 
 our %ARGS = (
     typemaps => "$RPerl::INCLUDE_PATH/typemap.rperl",
-    optimize => '-O3 -fomit-frame-pointer -march=native -mfpmath=sse -msse3 -g',  # disable default '-O2 -g' (or similar) from Perl core & Makemaker
+    optimize => '-O3 -fomit-frame-pointer -march=native -g',  # disable default '-O2 -g' (or similar) from Perl core & Makemaker
 
 # NEED UPGRADE: strip C++ incompat CFLAGS
 #  ccflags => $Config{ccflags} . ' -DNO_XSLOCKS -Wno-deprecated -std=c++0x -Wno-reserved-user-defined-literal -Wno-literal-suffix',
@@ -41,7 +41,6 @@ our %ARGS = (
     filters           => 'Preprocess',
     auto_include => # DEV NOTE: include non-RPerl files using AUTO_INCLUDE so they are not parsed by the 'Preprocess' filter
         [
-        '#include <immintrin.h>',  # SSE for high-speed math
         '#include <memory>',  # smart pointers for memory management
         '#include <iostream>',
         '#include <string>',


### PR DESCRIPTION
this patch removes SSE which are incompatible with ARM architecture

```
g++: error: unrecognized command line option -mfpmath=sse
g++: error: unrecognized command line option -msse3
```
see full log: http://www.cpantesters.org/cpan/report/58cbce1a-83a6-11e5-a4a8-dfc10b3facc5
