### PR TITLE
Ingore Vim-related noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,14 @@
 /RPerl-*.tar.gz
 /MakeMaker-*
 
+# Vim swap files
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+
 # [ NEED FIX: Unknown Files ]
 /out
 


### PR DESCRIPTION
Issue 42: Include the contents of vim.gitignore from the gitignore
project on github into .gitignore.
