### PR TITLE
Added C++ support for abs operator

### DIFF
--- a/lib/RPerl/Operation/Expression/Operator/Named.pm
+++ b/lib/RPerl/Operation/Expression/Operator/Named.pm
@@ -93,9 +93,50 @@ our string_hashref::method $ast_to_cpp__generate__CPPOPS_PERLTYPES = sub {
 
 our string_hashref::method $ast_to_cpp__generate__CPPOPS_CPPTYPES = sub {
     ( my object $self, my string_hashref $modes) = @_;
-    my string_hashref $cpp_source_group = { CPP => q{// <<< RP::O::E::O::N __DUMMY_SOURCE_CODE CPPOPS_CPPTYPES >>>} . "\n" };
+    my string_hashref $cpp_source_group = { CPP => q{} };
+    my string_hashref $cpp_source_subgroup;
 
-    #...
+    #    RPerl::diag( 'in Operator::Named->ast_to_cpp__generate(), received $self = ' . "\n" . RPerl::Parser::rperl_ast__dump($self) . "\n" );
+
+    my string $self_class = ref $self;
+    my string $operator_name;
+    if ( $self_class eq 'Operation_80' ) {    # Statement -> OP01_NAMED_SCOLON
+        $operator_name = substr $self->{children}->[0], 0, -1;
+    }
+    elsif (( $self_class eq 'Operator_84' )    # Operator -> OP01_NAMED SubExpression
+        or ( $self_class eq 'OperatorVoid_123' )
+        )                                   # OperatorVoid -> OP01_NAMED ListElement OP21_LIST_COMMA ListElements ';'
+    {
+        $operator_name = $self->{children}->[0];
+    }
+    elsif ( $self_class eq 'Operator_85' ) {    # Operator -> LPAREN OP01_NAMED ListElement OP21_LIST_COMMA ListElements ')'
+        $operator_name = $self->{children}->[1];
+    }
+    else {
+        die RPerl::Parser::rperl_rule__replace( 'ERROR ECOGEASRP00, CODE GENERATOR, ABSTRACT SYNTAX TO RPERL: Grammar rule '
+                . $self_class
+                . ' found where Operation_80, Operator_84, Operator_85, or OperatorVoid_123 expected, dying' )
+            . "\n";
+    }
+ 
+    # strip trailing whitespace, caused by the need to have the grammar match some tokens with a trailing whitespace, as with 'scalar ', etc.
+    $operator_name =~ s/^(\w+)\s*$/$1/gxms;
+
+ # DEV NOTE: compile-time operator name checking short-circuited first by Parse Phase 0 ERROR ECOPAPL02 'Bareword "FOO" not allowed while "strict subs" in use';
+ # can't figure out how to create test which gets past ECOPAPL02 to trigger ECOGEASCP13
+    if ( not exists $NAMES->{$operator_name} ) {
+        die q{ERROR ECOGEASCP13, CODE GENERATOR, ABSTRACT SYNTAX TO C++: unsupported or unrecognized named operator '}
+            . $operator_name
+            . q{' found where }
+            . ( join ', ', ( sort keys %{$NAMES} ) )
+            . ' expected, operator may not be properly listed in $RPerl::Operation::Expression::Operator::Named::NAMES, dying' . "\n";
+    }
+    my string $operator_class  = $NAMES->{$operator_name};
+    my object $operator_object = $operator_class->new();
+
+    $cpp_source_subgroup = $operator_object->ast_to_cpp__generate__CPPOPS_CPPTYPES( $self, $modes );
+    RPerl::Generator::source_group_append( $cpp_source_group, $cpp_source_subgroup );
+
     return $cpp_source_group;
 };
 

--- a/lib/RPerl/Operation/Expression/Operator/Named/AbsoluteValue.pm
+++ b/lib/RPerl/Operation/Expression/Operator/Named/AbsoluteValue.pm
@@ -93,13 +93,54 @@ our string_hashref::method $ast_to_cpp__generate__CPPOPS_PERLTYPES = sub {
 };
 
 our string_hashref::method $ast_to_cpp__generate__CPPOPS_CPPTYPES = sub {
-    ( my object $self, my string_hashref $modes) = @_;
+    ( my object $self, my object $operator_named, my string_hashref $modes) = @_;
     my string_hashref $cpp_source_group
-        = { CPP =>
-            q{// <<< RP::O::E::O::N::Abs __DUMMY_SOURCE_CODE CPPOPS_CPPTYPES >>>}
-            . "\n" };
+        = { CPP => q{} };
 
-    #...
+#    RPerl::diag( 'in Operator::Named::AbsoluteValue->ast_to_cpp__generate__CPPOPS_CPPTYPES(), received $self = ' . "\n" . RPerl::Parser::rperl_ast__dump($self) . "\n" );
+#    RPerl::diag( 'in Operator::Named::AbsoluteValue->ast_to_cpp__generate__CPPOPS_CPPTYPES(), received $operator_named = ' . "\n" . RPerl::Parser::rperl_ast__dump($operator_named) . "\n" );
+
+    my string $operator_named_class = ref $operator_named;
+    if ( $operator_named_class eq 'Operation_80' ) { # Operation -> OP01_NAMED_SCOLON
+        die RPerl::Parser::rperl_rule__replace(
+            'ERROR ECOGEASCP15, CODE GENERATOR, ABSTRACT SYNTAX TO C++: named operator '
+                . $operator_named->{children}->[0]
+                . ' requires exactly one argument, dying' )
+            . "\n";
+    }
+    elsif ( $operator_named_class eq 'Operator_84' ) { # Operator -> OP01_NAMED SubExpression
+	# DEV NOTE: math.h is added by default (see RPerl/Inline.pm)
+	# DEV NOTE: there are multiple standard abs functions in C++ but std::abs is the most versatile
+        $cpp_source_group->{CPP} .= "std::" . $operator_named->{children}->[0] . q{(}; 
+        my string_hashref $cpp_source_subgroup
+            = $operator_named->{children}->[1]
+            ->ast_to_cpp__generate__CPPOPS_CPPTYPES( $modes, $self );
+        RPerl::Generator::source_group_append( $cpp_source_group,
+            $cpp_source_subgroup );
+	$cpp_source_group->{CPP} .= ")"
+    }
+    elsif ( $operator_named_class eq 'Operator_85' ) { # Operator -> LPAREN OP01_NAMED ListElement OP21_LIST_COMMA ListElements ')'
+        die RPerl::Parser::rperl_rule__replace(
+            'ERROR ECOGEASCP13a, CODE GENERATOR, ABSTRACT SYNTAX TO C++: named operator '
+                . $operator_named->{children}->[1]
+                . ' does not accept multiple arguments, dying' )
+            . "\n";
+    }
+    elsif ( $operator_named_class eq 'OperatorVoid_123' ) { # OperatorVoid -> OP01_NAMED ListElement OP21_LIST_COMMA ListElements ';'
+        die RPerl::Parser::rperl_rule__replace(
+            'ERROR ECOGEASCP13b, CODE GENERATOR, ABSTRACT SYNTAX TO C++: named operator '
+                . $operator_named->{children}->[0]
+                . ' does not accept multiple arguments, dying' )
+            . "\n";
+    }
+    else {
+        die RPerl::Parser::rperl_rule__replace(
+            'ERROR ECOGEASRP00, CODE GENERATOR, ABSTRACT SYNTAX TO C++: grammar rule '
+                . ($operator_named_class)
+                . ' found where Operation_80, Operator_84, Operator_85, or OperatorVoid_123 expected, dying'
+        ) . "\n";
+    }
+
     return $cpp_source_group;
 };
 

--- a/lib/RPerl/Test/Operator01AbsoluteValue/program_00_good.cpp.CPPOPS_CPPTYPES
+++ b/lib/RPerl/Test/Operator01AbsoluteValue/program_00_good.cpp.CPPOPS_CPPTYPES
@@ -1,0 +1,27 @@
+#include <rperlstandalone.h>
+#ifndef __CPP__INCLUDED___cpp
+#define __CPP__INCLUDED___cpp 0.001_000
+# ifdef __CPP__TYPES
+int main() {
+    number foo = std::abs (3);
+    number bar = -3;
+    cout << (const string) "have $foo = ", foo, (const string) "\n";
+    cout << (const string) "have $bar = ", bar, (const string) "\n";
+    bar = foo + foo;
+    bar = std::abs (bar);
+    number float_number = -5.0;
+    number positive_float_number = -5.0;
+    cout << (const string) "have $foo = ", foo, (const string) "\n";
+    cout << (const string) "have $bar = ", bar, (const string) "\n";
+    cout << (const string) "have $float_number = ", float_number, (const string) "\n";
+    cout << (const string) "have $positive_float_number = ", positive_float_number, (const string) "\n";
+    float_number = std::abs (float_number);
+    positive_float_number = std::abs (positive_float_number);
+    cout << (const string) "have $float_number = ", float_number, (const string) "\n";
+    cout << (const string) "have $positive_float_number = ", positive_float_number, (const string) "\n";
+    return 0;
+}
+# elif defined __PERL__TYPES
+Purposefully_die_from_a_compile-time_error,_due_to____PERL__TYPES_being_defined.__We_need_to_define_only___CPP__TYPES_in_this_file!
+# endif
+#endif

--- a/lib/RPerl/Test/Operator01AbsoluteValue/program_01_good.cpp.CPPOPS_CPPTYPES
+++ b/lib/RPerl/Test/Operator01AbsoluteValue/program_01_good.cpp.CPPOPS_CPPTYPES
@@ -1,0 +1,27 @@
+#include <rperlstandalone.h>
+#ifndef __CPP__INCLUDED___cpp
+#define __CPP__INCLUDED___cpp 0.001_000
+# ifdef __CPP__TYPES
+int main() {
+    number foo = std::abs (3);
+    number bar = -3;
+    cout << (const string) "have $foo = ", foo, (const string) "\n";
+    cout << (const string) "have $bar = ", bar, (const string) "\n";
+    bar = foo + foo;
+    bar = std::abs (bar);
+    number float_number = -5.0;
+    number positive_float_number = -5.0;
+    cout << (const string) "have $foo = ", foo, (const string) "\n";
+    cout << (const string) "have $bar = ", bar, (const string) "\n";
+    cout << (const string) "have $float_number = ", float_number, (const string) "\n";
+    cout << (const string) "have $positive_float_number = ", positive_float_number, (const string) "\n";
+    float_number = std::abs (float_number);
+    positive_float_number = std::abs (positive_float_number);
+    cout << (const string) "have $float_number = ", float_number, (const string) "\n";
+    cout << (const string) "have $positive_float_number = ", positive_float_number, (const string) "\n";
+    return 0;
+}
+# elif defined __PERL__TYPES
+Purposefully_die_from_a_compile-time_error,_due_to____PERL__TYPES_being_defined.__We_need_to_define_only___CPP__TYPES_in_this_file!
+# endif
+#endif

--- a/lib/RPerl/Test/Operator01AbsoluteValue/program_02_good.cpp.CPPOPS_CPPTYPES
+++ b/lib/RPerl/Test/Operator01AbsoluteValue/program_02_good.cpp.CPPOPS_CPPTYPES
@@ -1,0 +1,27 @@
+#include <rperlstandalone.h>
+#ifndef __CPP__INCLUDED___cpp
+#define __CPP__INCLUDED___cpp 0.001_000
+# ifdef __CPP__TYPES
+int main() {
+    number foo = std::abs (3);
+    number bar = -3;
+    cout << (const string) "have $foo = ", foo, (const string) "\n";
+    cout << (const string) "have $bar = ", bar, (const string) "\n";
+    bar = foo + foo;
+    bar = std::abs (bar);
+    number float_number = -5.0;
+    number positive_float_number = -5.0;
+    cout << (const string) "have $foo = ", foo, (const string) "\n";
+    cout << (const string) "have $bar = ", bar, (const string) "\n";
+    cout << (const string) "have $float_number = ", float_number, (const string) "\n";
+    cout << (const string) "have $positive_float_number = ", positive_float_number, (const string) "\n";
+    float_number = std::abs (float_number);
+    positive_float_number = std::abs (positive_float_number);
+    cout << (const string) "have $float_number = ", float_number, (const string) "\n";
+    cout << (const string) "have $positive_float_number = ", positive_float_number, (const string) "\n";
+    return 0;
+}
+# elif defined __PERL__TYPES
+Purposefully_die_from_a_compile-time_error,_due_to____PERL__TYPES_being_defined.__We_need_to_define_only___CPP__TYPES_in_this_file!
+# endif
+#endif


### PR DESCRIPTION
I've tested this with a modified version of 13_generate.t. But it isn't included in this pull request.
Also named operators now delegate C++ ops and types code generation to operator.


