### PR TITLE
Paths aren't just \w chars, but shebang lines must be 1 line

### DIFF
--- a/lib/RPerl/Grammar.pm
+++ b/lib/RPerl/Grammar.pm
@@ -51,7 +51,7 @@ our $LEX = sub {
 
       m{\G(our\ hashref\ \$properties|\#\#\ no\ critic\ qw\(|use\ parent\ qw\(|use\ warnings\;|use\ constant|use\ strict\;|package|\$TYPED_|\=\ sub\ \{|foreach|while|\@ARG\;|undef|elsif|else|our|for|\@\{|if|\%\{|\}|\;|\)|\])}gc and return ($1, $1);
 
-      /\G(^#!\/(?:\w+\/)*perl)/gc and return ('SHEBANG', $1);
+      /\G(^#![^\r\n])*perl)/gc and return ('SHEBANG', $1);
       /\G(\s*use\s+RPerl\s*;\s*)/gc and return ('USE_RPERL', $1);
       /\G(\s*use\s+RPerl::AfterSubclass\s*;\s*)/gc and return ('USE_RPERL_AFTER', $1);
       /\G(use\s+)/gc and return ('USE', $1);

--- a/lib/RPerl/Grammar.pm
+++ b/lib/RPerl/Grammar.pm
@@ -51,7 +51,7 @@ our $LEX = sub {
 
       m{\G(our\ hashref\ \$properties|\#\#\ no\ critic\ qw\(|use\ parent\ qw\(|use\ warnings\;|use\ constant|use\ strict\;|package|\$TYPED_|\=\ sub\ \{|foreach|while|\@ARG\;|undef|elsif|else|our|for|\@\{|if|\%\{|\}|\;|\)|\])}gc and return ($1, $1);
 
-      /\G(^#![^\r\n])*perl)/gc and return ('SHEBANG', $1);
+      /\G(^#![^\r\n]*perl)/gc and return ('SHEBANG', $1);
       /\G(\s*use\s+RPerl\s*;\s*)/gc and return ('USE_RPERL', $1);
       /\G(\s*use\s+RPerl::AfterSubclass\s*;\s*)/gc and return ('USE_RPERL_AFTER', $1);
       /\G(use\s+)/gc and return ('USE', $1);


### PR DESCRIPTION
If the shebang line contains a character that matches \W (as the period did in my case), the grammar failed even though most characters that match \W are valid in paths.  It might be smart to make it aware of what characters are allowed in paths on the current operating system, but it doesn't really matter since it is being run by rperl not the command on the shebang anyway.