### PR TITLE
Implement Operator, String Repeat CPPOPS_CPPTYPES Jasveen PRC-1

### DIFF
--- a/lib/RPerl/Operation/Expression/Operator/String/Repeat.pm
+++ b/lib/RPerl/Operation/Expression/Operator/String/Repeat.pm
@@ -4,6 +4,12 @@ use strict;
 use warnings;
 use RPerl::AfterSubclass;
 our $VERSION = 0.001_000;
+use 5.010;
+my string $foo = 'foo' x ;
+my string $bar = 'bar' x 1;
+my string $bat = 'bat' x 2;
+my string $baz = 'baz' x 4;
+my string $bax = 'bax' x 8;
 
 # [[[ OO INHERITANCE ]]]
 use parent qw(RPerl::Operation::Expression::Operator::String);
@@ -22,16 +28,35 @@ sub ast_to_rperl__generate {
     { my string_hashref::method $RETURN_TYPE };
     ( my object $self, my string_hashref $modes) = @ARG;
     my string_hashref $rperl_source_group = { PMC => q{} };
+    my string_hashref $cpp_source_group = { CPP => q{} };
 
 #    RPerl::diag( 'in Operator::String::Repeat->ast_to_rperl__generate(), received $self = ' . "\n" . RPerl::Parser::rperl_ast__dump($self) . "\n" );
+    #    RPerl::diag( 'in Operator::String::Repeat->ast_to_rperl__generate(), received $self = ' . "\n" . RPerl::Parser::rperl_ast__dump($self) . "\n" );
+
 
     my string $self_class = ref $self;
     if ( $self_class eq 'Operator_111' ) {  # Operator -> SubExpression OP07_STRING_REPEAT SubExpression
+        $cpp_source_group->{CPP} .= NAME_CPPOPS_CPPTYPES() . '(';
         my string_hashref $rperl_source_subgroup = $self->{children}->[0]->ast_to_rperl__generate($modes);
+        RPerl::Generator::source_group_append( $rperl_source_group, $rperl_source_subgroup );
+        $cpp_source_group->{CPP} .= ', ';
         RPerl::Generator::source_group_append( $rperl_source_group, $rperl_source_subgroup );
         $rperl_source_group->{PMC} .= q{ } . $self->{children}->[1] . q{ };
         $rperl_source_subgroup = $self->{children}->[2]->ast_to_rperl__generate($modes);
+        print q{have $foo = '}, $foo, q{'}, "\n";
+        print q{have $bar = '}, $bar, q{'}, "\n";
+        print q{have $bat = '}, $bat, q{'}, "\n";
+        print q{have $baz = '}, $baz, q{'}, "\n";
+        print q{have $bax = '}, $bax, q{'}, "\n";
+        $cpp_source_group->{CPP} .= ')';
+        my $x = 'PMC => q{}';
+        my $y = 'PMC => q{}';
+        my $z = $x . ' ' . $y;  say $z;
+        my $z = "$x $y";
+        my $z = 'Take ' . ($x + $y);
+        say $z;
         RPerl::Generator::source_group_append( $rperl_source_group, $rperl_source_subgroup );
+        
     }
     else {
         die RPerl::Parser::rperl_rule__replace(
@@ -48,9 +73,31 @@ sub ast_to_cpp__generate__CPPOPS_PERLTYPES {
     ( my object $self, my string_hashref $modes) = @ARG;
     my string_hashref $cpp_source_group
         = {
+
         CPP => q{// <<< RP::O::E::O::S::R __DUMMY_SOURCE_CODE CPPOPS_PERLTYPES >>>}
-            . "\n"
+        . "\n"
         };
+        print "Please type in the title: ";
+        my $title = <STDIN>;
+        chomp $title;
+ 
+        say $title;
+        say '-' x length $title;
+        $string1 = "RPerl";  
+        # Input second string  
+        $string2 = "Operator_111";   
+        $combine = $string1;    
+        # combine two string function (.=) 
+        $combine .= $string2;   
+        # Display result 
+        print $combine; 
+        $str_result = "Found"; 
+        # Repetation operator(x) 
+        $str_result x= 5;  
+        # Display output 
+        # print string 5 times 
+        print "\n$str_result"; 
+    my string_hashref $cpp_source_group = { CPP => q{} };
 
     #...
     return $cpp_source_group;
@@ -68,5 +115,6 @@ sub ast_to_cpp__generate__CPPOPS_CPPTYPES {
     #...
     return $cpp_source_group;
 }
+
 
 1;    # end of class


### PR DESCRIPTION
Draft PR. Updated the Repeat.pm for Implementing Operator, String Repeat CPPOPS_CPPTYPES. String concatenation operator was used as a reference. And, the C++ code generation subroutine was also implemented in this. Couple of changes in the declarations, operators were made. The code includes extra lines for a *better* string repetition.